### PR TITLE
Remove timezone param from xpsummaries request

### DIFF
--- a/operations/xpsummaries.yaml
+++ b/operations/xpsummaries.yaml
@@ -4,12 +4,6 @@ get:
   summary: Returns user XP summaries
   description: User summaries.
   parameters:
-    - in: query
-      name: timezone
-      required: true
-      type: string
-      minimum: 1
-      description: Time zone
     - in: path
       name: userID
       required: true


### PR DESCRIPTION
I was going to open an issue, but this seemed friendlier for the amount of effort. _As far as i can tell_ including timezone doesn’t change API response at all. it’s always going to be based on GMT, much to my disappointment.